### PR TITLE
feat: DataStore 설정 추가

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -56,6 +56,8 @@ kotlin {
 
             implementation(libs.androidx.room.runtime)
             implementation(libs.sqlite.bundled)
+
+            implementation(libs.androidx.datastore.preferences)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/composeApp/src/androidMain/kotlin/com/chukchukhaksa/mobile/local/datastore/ChukChukHaksaDataStoreFactory.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/chukchukhaksa/mobile/local/datastore/ChukChukHaksaDataStoreFactory.android.kt
@@ -1,0 +1,21 @@
+package com.chukchukhaksa.mobile.local.datastore
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import okio.Path.Companion.toPath
+
+actual class ChukChukHaksaDataStoreFactory(
+    private val context: Context
+) {
+    actual fun createChukChukHaksaDataStore(): DataStore<Preferences> =
+        PreferenceDataStoreFactory.createWithPath(
+            produceFile = {
+                context.filesDir
+                    .resolve(CHUK_CHUK_HAKSA_DATA_STORE_FILE_NAME)
+                    .absolutePath
+                    .toPath()
+            }
+        )
+}

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/di/DataModules.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/di/DataModules.kt
@@ -1,7 +1,8 @@
 package com.chukchukhaksa.mobile.di
 
+import com.chukchukhaksa.mobile.local.datastore.di.dataStoreModule
 import org.koin.dsl.module
 
 val dataModule = module {
-    /*TODO("data 계층 추가 후 작업")*/
+    dataStoreModule
 }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/di/InitKoin.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/di/InitKoin.kt
@@ -8,9 +8,8 @@ fun initKoin(config: KoinAppDeclaration? = null) {
     startKoin {
         config?.invoke(this)
         modules(
-//            공통으로 사용되는 module
             domainModule,
-//            dataModule,
+            dataModule,
             databaseModule,
             presentationModule
 //            platformModule -> 각 플랫폼 별로 module이 다른 경우

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/local/datastore/ChukChukHaksaDataStoreFactory.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/local/datastore/ChukChukHaksaDataStoreFactory.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chukchukhaksa.mobile.local.datastore
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+
+expect class ChukChukHaksaDataStoreFactory {
+    fun createChukChukHaksaDataStore(): DataStore<Preferences>
+}
+
+internal const val CHUK_CHUK_HAKSA_DATA_STORE_FILE_NAME = "chuk-chuk-haksa-preference.preferences_pb"

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/local/datastore/di/dataStoreModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/local/datastore/di/dataStoreModule.kt
@@ -1,0 +1,9 @@
+package com.chukchukhaksa.mobile.local.datastore.di
+
+import com.chukchukhaksa.mobile.local.datastore.ChukChukHaksaDataStoreFactory
+import org.koin.dsl.module
+
+val dataStoreModule =
+    module {
+        single { get<ChukChukHaksaDataStoreFactory>().createChukChukHaksaDataStore() }
+    }

--- a/composeApp/src/iosMain/kotlin/com/chukchukhaksa/mobile/local/datastore/ChukChukHaksaDataStoreFactory.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/chukchukhaksa/mobile/local/datastore/ChukChukHaksaDataStoreFactory.ios.kt
@@ -1,0 +1,32 @@
+package com.chukchukhaksa.mobile.local.datastore
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import kotlinx.cinterop.ExperimentalForeignApi
+import okio.Path.Companion.toPath
+import platform.Foundation.NSDocumentDirectory
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSUserDomainMask
+
+actual class ChukChukHaksaDataStoreFactory {
+    actual fun createChukChukHaksaDataStore(): DataStore<Preferences> =
+        PreferenceDataStoreFactory.createWithPath(
+            produceFile = {
+                getDocumentPath(CHUK_CHUK_HAKSA_DATA_STORE_FILE_NAME).toPath()
+            }
+        )
+
+    @OptIn(ExperimentalForeignApi::class)
+    private fun getDocumentPath(fileName: String): String {
+        val directory =
+            NSFileManager.defaultManager.URLForDirectory(
+                directory = NSDocumentDirectory,
+                inDomain = NSUserDomainMask,
+                appropriateForURL = null,
+                create = false,
+                error = null,
+            )
+        return requireNotNull(directory).path + "/$fileName"
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ androidx-espresso = "3.6.1"
 androidx-lifecycle = "2.8.4"
 androidx-testExt = "1.2.1"
 composeMultiplatform = "1.8.0"
+datastorePreferences = "1.1.7"
 junit = "4.13.2"
 kotlin = "2.1.20"
 kotlinx-immutable = "0.3.8"
@@ -22,6 +23,7 @@ androidx-room = "2.7.1"
 ksp = "2.1.20-1.0.32"
 
 [libraries]
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlin-testJunit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }


### PR DESCRIPTION
- `ChukChukHaksaDataStoreFactory`를 추가하여 Android와 iOS에서 DataStore를 생성하도록 구현
- `dataStoreModule`을 추가하여 Koin에 DataStore 의존성 주입
- `dataModule`에 `dataStoreModule` 추가
- `build.gradle.kts`에 DataStore 의존성 추가
- `libs.versions.toml`에 DataStore 버전 정보 추가

마찬가지로 코드 리뷰 후 머지합니다