### PR TITLE
feat: 시간표 관련 데이터 레이어 구현

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/model/TimetableExceptions.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/model/TimetableExceptions.kt
@@ -1,0 +1,14 @@
+package com.chukchukhaksa.mobile.common.model
+
+class TimetableCellOverlapException(
+    val name: String,
+    val startPeriod: Int,
+    val endPeriod: Int,
+    override val message: String = "겹치는 시간이 있어요\n$name ($startPeriod - $endPeriod)",
+) : RuntimeException()
+
+class TimetableCellPeriodInvalidException(
+    val startPeriod: Int,
+    val endPeriod: Int,
+    override val message: String = "교시를 확인해주세요 (${startPeriod}교시 - ${endPeriod}교시)",
+) : RuntimeException()

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/timetable/datasource/LocalTimetableDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/timetable/datasource/LocalTimetableDataSource.kt
@@ -1,0 +1,24 @@
+package com.chukchukhaksa.mobile.data.timetable.datasource
+
+import com.chukchukhaksa.mobile.common.model.Timetable
+import kotlinx.coroutines.flow.Flow
+
+interface LocalTimetableDataSource {
+  suspend fun getAllTimetable(): List<Timetable>
+
+  suspend fun getTimetable(createTime: Long): Timetable?
+
+  suspend fun setMainTimetableCreateTime(createTime: Long)
+
+  suspend fun getMainTimetableCreateTime(): Flow<Long?>
+
+  suspend fun deleteAllTimetable()
+
+  suspend fun deleteTimetable(data: Timetable)
+
+  suspend fun updateTimetable(data: Timetable)
+  suspend fun insertTimetable(data: Timetable)
+
+  suspend fun getTimetableCellType(): Flow<String>
+  suspend fun setTimetableCellType(type: String)
+}

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/timetable/di/TitmetableRepositoryModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/timetable/di/TitmetableRepositoryModule.kt
@@ -1,0 +1,10 @@
+package com.chukchukhaksa.mobile.data.timetable.di
+
+import com.chukchukhaksa.mobile.data.timetable.repository.TimetableRepositoryImpl
+import com.chukchukhaksa.mobile.domain.timetable.repository.TimetableRepository
+import org.koin.dsl.module
+
+val timetableRepositoryModule = module {
+//    single<OpenLectureRepository> { OpenLectureRepositoryImpl(get(), get()) }
+    single<TimetableRepository> { TimetableRepositoryImpl(get()) }
+}

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/timetable/repository/TimetableRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/timetable/repository/TimetableRepositoryImpl.kt
@@ -1,0 +1,156 @@
+package com.chukchukhaksa.mobile.data.timetable.repository
+
+import com.chukchukhaksa.mobile.common.model.Timetable
+import com.chukchukhaksa.mobile.common.model.TimetableCell
+import com.chukchukhaksa.mobile.common.model.TimetableCellOverlapException
+import com.chukchukhaksa.mobile.common.model.TimetableCellPeriodInvalidException
+import com.chukchukhaksa.mobile.common.model.TimetableDay
+import com.chukchukhaksa.mobile.data.timetable.datasource.LocalTimetableDataSource
+import com.chukchukhaksa.mobile.domain.timetable.repository.TimetableRepository
+import kotlinx.coroutines.flow.firstOrNull
+
+class TimetableRepositoryImpl(
+    private val localTimetableDataSource: LocalTimetableDataSource,
+) : TimetableRepository {
+    override suspend fun getAllTimetable(): List<Timetable> {
+        return localTimetableDataSource.getAllTimetable()
+    }
+
+    override suspend fun getTimetable(createTime: Long): Timetable? {
+        return localTimetableDataSource.getTimetable(createTime)
+    }
+
+    override suspend fun setMainTimetableCreateTime(createTime: Long) {
+        localTimetableDataSource.setMainTimetableCreateTime(createTime)
+    }
+
+    override suspend fun getMainTimetableCreateTime(): Long? {
+        return localTimetableDataSource
+            .getMainTimetableCreateTime()
+            .firstOrNull()
+            ?: getAllTimetable()
+                .firstOrNull()
+                ?.createTime
+                ?.apply {
+                    setMainTimetableCreateTime(this)
+                }
+    }
+
+    override suspend fun deleteTimetable(data: Timetable) {
+        localTimetableDataSource.deleteTimetable(data)
+    }
+
+    override suspend fun insertTimetable(data: Timetable) {
+        localTimetableDataSource.insertTimetable(data)
+    }
+
+    override suspend fun updateTimetable(
+        createTime: Long,
+        year: String,
+        semester: String,
+        name: String,
+    ) = with(localTimetableDataSource) {
+        val timetable = getTimetable(createTime)
+        updateTimetable(
+            timetable!!.copy(
+                year = year,
+                semester = semester,
+                name = name,
+            ),
+        )
+    }
+
+    override suspend fun insertTimetableCell(cellList: List<TimetableCell>) {
+        val timetable = getMainTimetable()!!
+        checkPeriodInvalid(cellList)
+        checkCellOverlap(cellList, cellList)
+        checkCellOverlap(cellList, timetable.cellList)
+        localTimetableDataSource.updateTimetable(
+            timetable.copy(
+                cellList = timetable.cellList.plus(cellList),
+            ),
+        )
+    }
+
+    override suspend fun deleteTimetableCell(cell: TimetableCell): Timetable {
+        val timetable = getMainTimetable()!!
+            .run {
+                copy(cellList = cellList.minus(cell))
+            }
+        localTimetableDataSource.updateTimetable(
+            timetable,
+        )
+        return timetable
+    }
+
+    override suspend fun updateTimetableCell(oldCellId: String, cellList: List<TimetableCell>) {
+        val timetable = getMainTimetable()!!
+        val tempCellList = timetable.cellList.filter { it.id != oldCellId }
+
+        checkPeriodInvalid(cellList)
+        checkCellOverlap(cellList, cellList)
+        checkCellOverlap(cellList, tempCellList)
+
+        localTimetableDataSource.updateTimetable(
+            timetable.copy(
+                cellList = tempCellList.plus(cellList),
+            ),
+        )
+    }
+
+    private suspend fun getMainTimetable() = with(localTimetableDataSource) {
+        val createTime = getMainTimetableCreateTime().firstOrNull() ?: return@with null
+        getTimetable(createTime)
+    }
+
+    private fun checkPeriodInvalid(
+        cellList: List<TimetableCell>,
+    ) {
+        cellList.filter { it.day != TimetableDay.E_LEARNING }.forEach { cell ->
+            val isNotValid = cell.startPeriod > cell.endPeriod ||
+                    cell.startPeriod !in 1..15 ||
+                    cell.endPeriod !in 1..15
+            if (isNotValid) {
+                throw TimetableCellPeriodInvalidException(
+                    startPeriod = cell.startPeriod,
+                    endPeriod = cell.endPeriod,
+                )
+            }
+        }
+    }
+
+    private fun checkCellOverlap(
+        toInsertCellList: List<TimetableCell>,
+        currentCellList: List<TimetableCell>,
+    ) {
+        toInsertCellList.forEach { toInsertCell ->
+            currentCellList
+                .filter { it.day == toInsertCell.day }
+                .filter { it.id != toInsertCell.id }
+                .filter { it.day != TimetableDay.E_LEARNING }
+                .forEach { sameDayCell ->
+                    val isOverlap =
+                        toInsertCell.startPeriod in sameDayCell.startPeriod..sameDayCell.endPeriod ||
+                                toInsertCell.endPeriod in sameDayCell.startPeriod..sameDayCell.endPeriod ||
+                                sameDayCell.startPeriod in toInsertCell.startPeriod..toInsertCell.endPeriod ||
+                                sameDayCell.endPeriod in toInsertCell.startPeriod..toInsertCell.endPeriod
+
+                    if (isOverlap) {
+                        throw TimetableCellOverlapException(
+                            name = sameDayCell.name,
+                            startPeriod = sameDayCell.startPeriod,
+                            endPeriod = sameDayCell.endPeriod,
+                        )
+                    }
+                }
+        }
+    }
+
+    override suspend fun getTimetableCellType(): String {
+        return localTimetableDataSource.getTimetableCellType().firstOrNull() ?: ""
+    }
+
+    override suspend fun setTimetableCellType(type: String) {
+        localTimetableDataSource.setTimetableCellType(type)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/di/DataModules.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/di/DataModules.kt
@@ -1,8 +1,10 @@
 package com.chukchukhaksa.mobile.di
 
+import com.chukchukhaksa.mobile.local.datasource.timetable.di.localTimetableDataSourceModule
 import com.chukchukhaksa.mobile.local.datastore.di.dataStoreModule
 import org.koin.dsl.module
 
 val dataModule = module {
     dataStoreModule
+    localTimetableDataSourceModule
 }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/local/datasource/timetable/LocalTimetableDatasourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/local/datasource/timetable/LocalTimetableDatasourceImpl.kt
@@ -1,0 +1,73 @@
+package com.chukchukhaksa.mobile.local.datasource.timetable
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.chukchukhaksa.mobile.common.model.Timetable
+import com.chukchukhaksa.mobile.data.timetable.datasource.LocalTimetableDataSource
+import com.chukchukhaksa.mobile.local.common.database.database.TimetableDatabase
+import com.chukchukhaksa.mobile.local.datasource.timetable.converter.toEntity
+import com.chukchukhaksa.mobile.local.datasource.timetable.converter.toModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+
+class LocalTimetableDatasourceImpl(
+    private val dataStore: DataStore<Preferences>,
+    private val timetableDatabase: TimetableDatabase,
+) : LocalTimetableDataSource {
+    private val ioDispatcher = Dispatchers.IO
+
+    companion object {
+        private val MAIN_TIMETABLE_CREATE_TIME =
+            longPreferencesKey("[KEY] is main timetable create time")
+        private val TIMETABLE_CELL_TYPE = stringPreferencesKey("[KEY] is main timetable cell type")
+    }
+
+    private val data: Flow<Preferences>
+        get() = dataStore.data
+
+    override suspend fun getAllTimetable(): List<Timetable> = withContext(ioDispatcher) {
+        timetableDatabase.timetableDao().getAll().map { it.toModel() }
+    }
+
+    override suspend fun getTimetable(createTime: Long): Timetable? = withContext(ioDispatcher) {
+        timetableDatabase.timetableDao().get(createTime)?.toModel()
+    }
+
+    override suspend fun deleteAllTimetable() = withContext(ioDispatcher) {
+        timetableDatabase.timetableDao().deleteAll()
+    }
+
+    override suspend fun deleteTimetable(data: Timetable) = withContext(ioDispatcher) {
+        timetableDatabase.timetableDao().delete(data.toEntity())
+    }
+
+    override suspend fun updateTimetable(data: Timetable) = withContext(ioDispatcher) {
+        timetableDatabase.timetableDao().update(data.toEntity())
+    }
+
+    override suspend fun insertTimetable(data: Timetable) {
+        timetableDatabase.timetableDao().insert(data.toEntity())
+    }
+
+    override suspend fun setMainTimetableCreateTime(createTime: Long) {
+        dataStore.edit { it[MAIN_TIMETABLE_CREATE_TIME] = createTime }
+    }
+
+    override suspend fun getMainTimetableCreateTime(): Flow<Long?> {
+        return data.map { it[MAIN_TIMETABLE_CREATE_TIME] }
+    }
+
+    override suspend fun getTimetableCellType(): Flow<String> {
+        return data.map { it[TIMETABLE_CELL_TYPE] ?: "" }
+    }
+
+    override suspend fun setTimetableCellType(type: String) {
+        dataStore.edit { it[TIMETABLE_CELL_TYPE] = type }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/local/datasource/timetable/converter/Timetable.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/local/datasource/timetable/converter/Timetable.kt
@@ -1,0 +1,12 @@
+package com.chukchukhaksa.mobile.local.datasource.timetable.converter
+
+import com.chukchukhaksa.mobile.common.model.Timetable
+import com.chukchukhaksa.mobile.local.common.database.entity.TimetableEntity
+
+fun Timetable.toEntity() = TimetableEntity(
+    createTime = createTime,
+    year = year,
+    semester = semester,
+    name = name,
+    cellList = cellList,
+)

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/local/datasource/timetable/converter/TimetableEntity.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/local/datasource/timetable/converter/TimetableEntity.kt
@@ -1,0 +1,12 @@
+package com.chukchukhaksa.mobile.local.datasource.timetable.converter
+
+import com.chukchukhaksa.mobile.common.model.Timetable
+import com.chukchukhaksa.mobile.local.common.database.entity.TimetableEntity
+
+fun TimetableEntity.toModel() = Timetable(
+    createTime = createTime,
+    year = year,
+    semester = semester,
+    name = name,
+    cellList = cellList,
+)

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/local/datasource/timetable/di/LocalTimetableDataSourceModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/local/datasource/timetable/di/LocalTimetableDataSourceModule.kt
@@ -1,0 +1,15 @@
+package com.chukchukhaksa.mobile.local.datasource.timetable.di
+
+import com.chukchukhaksa.mobile.data.timetable.datasource.LocalTimetableDataSource
+import com.chukchukhaksa.mobile.local.datasource.timetable.LocalTimetableDatasourceImpl
+import org.koin.dsl.module
+
+val localTimetableDataSourceModule = module {
+    single<LocalTimetableDataSource> {
+        LocalTimetableDatasourceImpl(get(), get())
+    }
+
+//  single<LocalOpenLectureDataSource> {
+//    LocalOpenLectureDatasourceImpl(get(named("normalDataStore")), get())
+//  }
+}


### PR DESCRIPTION
- 시간표 관련 로컬 데이터 소스, 데이터 소스 구현체, 레포지토리 구현체를 추가했습니다.
- 시간표 엔티티와 모델 간 변환 함수를 추가했습니다.
- 시간표 관련 의존성 주입 모듈을 추가했습니다.
- 시간표 관련 예외 클래스를 정의했습니다. (중복 시간, 잘못된 교시)
- DataModules에 시간표 관련 모듈을 추가했습니다.