### PR TITLE
feat: Timetable UseCase에 Repository 적용

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/di/DomainModules.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/di/DomainModules.kt
@@ -23,20 +23,20 @@ val domainModule = module {
     // OpenMajor
     factory { GetOpenMajorListUseCase() }
 
-    // Timetable
-    factory { DeleteTimetableUseCase() }
-    factory { GetAllTimetableUseCase() }
-    factory { GetMainTimetableUseCase() }
-    factory { InsertTimetableUseCase() }
-    factory { UpdateTimetableUseCase() }
-    factory { SetMainTimetableCreateTime() }
+    // Timetable management use cases
+    factory { DeleteTimetableUseCase(get()) }
+    factory { GetAllTimetableUseCase(get()) }
+    factory { GetMainTimetableUseCase(get()) }
+    factory { InsertTimetableUseCase(get()) }
+    factory { UpdateTimetableUseCase(get()) }
+    factory { SetMainTimetableCreateTime(get()) }
 
     // Timetable cell use cases
-    factory { DeleteTimetableCellUseCase() }
-    factory { InsertTimetableCellUseCase() }
-    factory { UpdateTimetableCellUseCase() }
-    factory { GetTimetableCellTypeUseCase() }
-    factory { SetTimetableCellTypeUseCase() }
+    factory { DeleteTimetableCellUseCase(get()) }
+    factory { InsertTimetableCellUseCase(get()) }
+    factory { UpdateTimetableCellUseCase(get()) }
+    factory { GetTimetableCellTypeUseCase(get()) }
+    factory { SetTimetableCellTypeUseCase(get()) }
 
     // Open lecture use cases
     factory { GetOpenLectureListUseCase() }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/timetable/usecase/DeleteTimetableCellUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/timetable/usecase/DeleteTimetableCellUseCase.kt
@@ -2,8 +2,13 @@ package com.chukchukhaksa.mobile.domain.timetable.usecase
 
 import com.chukchukhaksa.mobile.common.model.Timetable
 import com.chukchukhaksa.mobile.common.model.TimetableCell
+import com.chukchukhaksa.mobile.domain.common.runCatchingIgnoreCancelled
+import com.chukchukhaksa.mobile.domain.timetable.repository.TimetableRepository
 
-class DeleteTimetableCellUseCase {
-    suspend operator fun invoke(cell: TimetableCell): Result<Timetable> =
-        Result.success(Timetable())
+class DeleteTimetableCellUseCase(
+    private val timetableRepository: TimetableRepository,
+) {
+    suspend operator fun invoke(cell: TimetableCell): Result<Timetable> = runCatchingIgnoreCancelled {
+        timetableRepository.deleteTimetableCell(cell = cell)
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/timetable/usecase/DeleteTimetableUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/timetable/usecase/DeleteTimetableUseCase.kt
@@ -1,8 +1,22 @@
 package com.chukchukhaksa.mobile.domain.timetable.usecase
 
 import com.chukchukhaksa.mobile.common.model.Timetable
+import com.chukchukhaksa.mobile.domain.common.runCatchingIgnoreCancelled
+import com.chukchukhaksa.mobile.domain.timetable.repository.TimetableRepository
 
 
-class DeleteTimetableUseCase {
-    suspend operator fun invoke(timetable: Timetable): Result<Unit> = Result.success(Unit)
+class DeleteTimetableUseCase(
+    private val timetableRepository: TimetableRepository,
+) {
+    suspend operator fun invoke(timetable: Timetable): Result<Unit> = runCatchingIgnoreCancelled {
+        with(timetableRepository) {
+            deleteTimetable(timetable)
+
+            val mainTimetableCreateTime = getMainTimetableCreateTime()
+            if (mainTimetableCreateTime != timetable.createTime) return@runCatchingIgnoreCancelled
+
+            val firstTimetableCreateTime = getAllTimetable().firstOrNull()?.createTime ?: 0L
+            setMainTimetableCreateTime(firstTimetableCreateTime)
+        }
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/timetable/usecase/GetAllTimetableUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/timetable/usecase/GetAllTimetableUseCase.kt
@@ -3,17 +3,13 @@ package com.chukchukhaksa.mobile.domain.timetable.usecase
 import com.chukchukhaksa.mobile.common.model.Timetable
 import com.chukchukhaksa.mobile.common.model.TimetableCell
 import com.chukchukhaksa.mobile.common.model.TimetableCellColor
+import com.chukchukhaksa.mobile.domain.common.runCatchingIgnoreCancelled
+import com.chukchukhaksa.mobile.domain.timetable.repository.TimetableRepository
 
-class GetAllTimetableUseCase {
-    suspend operator fun invoke(): Result<List<Timetable>> = Result.success(
-        listOf(
-            Timetable(
-                createTime = 0,
-                year = "2025",
-                semester = "1",
-                name = "왕덕팔 시간표",
-                cellList = listOf(TimetableCell(color = TimetableCellColor.GRAY)),
-            )
-        )
-    )
+class GetAllTimetableUseCase(
+    private val timetableRepository: TimetableRepository,
+) {
+    suspend operator fun invoke(): Result<List<Timetable>> = runCatchingIgnoreCancelled {
+        timetableRepository.getAllTimetable()
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/timetable/usecase/GetMainTimetableUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/timetable/usecase/GetMainTimetableUseCase.kt
@@ -3,15 +3,16 @@ package com.chukchukhaksa.mobile.domain.timetable.usecase
 import com.chukchukhaksa.mobile.common.model.Timetable
 import com.chukchukhaksa.mobile.common.model.TimetableCell
 import com.chukchukhaksa.mobile.common.model.TimetableCellColor
+import com.chukchukhaksa.mobile.domain.common.runCatchingIgnoreCancelled
+import com.chukchukhaksa.mobile.domain.timetable.repository.TimetableRepository
 
-class GetMainTimetableUseCase {
-    suspend operator fun invoke(): Result<Timetable?> = Result.success(
-        Timetable(
-            createTime = 0,
-            year = "2025",
-            semester = "1",
-            name = "왕덕팔 시간표",
-            cellList = listOf(TimetableCell(color = TimetableCellColor.GRAY)),
-        )
-    )
+class GetMainTimetableUseCase(
+    private val timetableRepository: TimetableRepository,
+) {
+    suspend operator fun invoke(): Result<Timetable?> = runCatchingIgnoreCancelled {
+        with(timetableRepository) {
+            val createTime = getMainTimetableCreateTime() ?: return@with null
+            getTimetable(createTime)
+        }
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/timetable/usecase/GetTimetableCellTypeUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/timetable/usecase/GetTimetableCellTypeUseCase.kt
@@ -1,9 +1,12 @@
 package com.chukchukhaksa.mobile.domain.timetable.usecase
 
 import com.chukchukhaksa.mobile.domain.common.runCatchingIgnoreCancelled
+import com.chukchukhaksa.mobile.domain.timetable.repository.TimetableRepository
 
-class GetTimetableCellTypeUseCase {
+class GetTimetableCellTypeUseCase(
+    private val timetableRepository: TimetableRepository,
+) {
     suspend operator fun invoke() = runCatchingIgnoreCancelled {
-        ""
+        timetableRepository.getTimetableCellType()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/timetable/usecase/InsertTimetableCellUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/timetable/usecase/InsertTimetableCellUseCase.kt
@@ -1,7 +1,16 @@
 package com.chukchukhaksa.mobile.domain.timetable.usecase
 
 import com.chukchukhaksa.mobile.common.model.TimetableCell
+import com.chukchukhaksa.mobile.domain.common.runCatchingIgnoreCancelled
+import com.chukchukhaksa.mobile.domain.timetable.repository.TimetableRepository
 
-class InsertTimetableCellUseCase{
-    suspend operator fun invoke(cellList: List<TimetableCell>): Result<Unit> = Result.success(Unit)
+class InsertTimetableCellUseCase(
+    private val timetableRepository: TimetableRepository,
+) {
+    suspend operator fun invoke(cellList: List<TimetableCell>): Result<Unit> =
+        runCatchingIgnoreCancelled {
+            timetableRepository.insertTimetableCell(
+                cellList = cellList,
+            )
+        }
 }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/timetable/usecase/InsertTimetableUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/timetable/usecase/InsertTimetableUseCase.kt
@@ -1,7 +1,30 @@
 package com.chukchukhaksa.mobile.domain.timetable.usecase
 
-class InsertTimetableUseCase{
-    suspend operator fun invoke(param: Param): Result<Unit> = Result.success(Unit)
+import com.chukchukhaksa.mobile.common.model.Timetable
+import com.chukchukhaksa.mobile.domain.common.runCatchingIgnoreCancelled
+import com.chukchukhaksa.mobile.domain.timetable.repository.TimetableRepository
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+class InsertTimetableUseCase(
+    private val timetableRepository: TimetableRepository,
+) {
+    @OptIn(ExperimentalTime::class)
+    suspend operator fun invoke(param: Param): Result<Unit> = runCatchingIgnoreCancelled {
+        val createTime = Clock.System.now().toEpochMilliseconds()
+        with(timetableRepository) {
+            insertTimetable(
+                Timetable(
+                    createTime = createTime,
+                    year = param.year,
+                    semester = param.semester,
+                    name = param.name,
+                    cellList = emptyList(),
+                ),
+            )
+            setMainTimetableCreateTime(createTime)
+        }
+    }
 
     data class Param(
         val name: String,

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/timetable/usecase/SetMainTimetableCreateTime.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/timetable/usecase/SetMainTimetableCreateTime.kt
@@ -1,5 +1,12 @@
 package com.chukchukhaksa.mobile.domain.timetable.usecase
 
-class SetMainTimetableCreateTime{
-    suspend operator fun invoke(createTime: Long): Result<Unit> = Result.success(Unit)
+import com.chukchukhaksa.mobile.domain.common.runCatchingIgnoreCancelled
+import com.chukchukhaksa.mobile.domain.timetable.repository.TimetableRepository
+
+class SetMainTimetableCreateTime(
+    private val timetableRepository: TimetableRepository,
+) {
+    suspend operator fun invoke(createTime: Long): Result<Unit> = runCatchingIgnoreCancelled {
+        timetableRepository.setMainTimetableCreateTime(createTime)
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/timetable/usecase/SetTimetableCellTypeUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/timetable/usecase/SetTimetableCellTypeUseCase.kt
@@ -1,8 +1,12 @@
 package com.chukchukhaksa.mobile.domain.timetable.usecase
 
 import com.chukchukhaksa.mobile.domain.common.runCatchingIgnoreCancelled
+import com.chukchukhaksa.mobile.domain.timetable.repository.TimetableRepository
 
-class SetTimetableCellTypeUseCase{
+class SetTimetableCellTypeUseCase(
+    private val timetableRepository: TimetableRepository,
+) {
     suspend operator fun invoke(type: String) = runCatchingIgnoreCancelled {
+        timetableRepository.setTimetableCellType(type)
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/timetable/usecase/UpdateTimetableCellUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/timetable/usecase/UpdateTimetableCellUseCase.kt
@@ -1,9 +1,18 @@
 package com.chukchukhaksa.mobile.domain.timetable.usecase
 
 import com.chukchukhaksa.mobile.common.model.TimetableCell
+import com.chukchukhaksa.mobile.domain.common.runCatchingIgnoreCancelled
+import com.chukchukhaksa.mobile.domain.timetable.repository.TimetableRepository
 
-class UpdateTimetableCellUseCase() {
-    suspend operator fun invoke(param: Param): Result<Unit> = Result.success(Unit)
+class UpdateTimetableCellUseCase(
+    private val timetableRepository: TimetableRepository,
+) {
+    suspend operator fun invoke(param: Param): Result<Unit> = runCatchingIgnoreCancelled {
+        timetableRepository.updateTimetableCell(
+            oldCellId = param.oldCellId,
+            cellList = param.cellList
+        )
+    }
 
     data class Param(
         val oldCellId: String,

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/timetable/usecase/UpdateTimetableUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/timetable/usecase/UpdateTimetableUseCase.kt
@@ -1,7 +1,21 @@
 package com.chukchukhaksa.mobile.domain.timetable.usecase
 
-class UpdateTimetableUseCase{
-    suspend operator fun invoke(param: Param): Result<Unit> = Result.success(Unit)
+import com.chukchukhaksa.mobile.domain.common.runCatchingIgnoreCancelled
+import com.chukchukhaksa.mobile.domain.timetable.repository.TimetableRepository
+
+class UpdateTimetableUseCase(
+    private val timetableRepository: TimetableRepository,
+) {
+    suspend operator fun invoke(param: Param): Result<Unit> = runCatchingIgnoreCancelled {
+        with(param) {
+            timetableRepository.updateTimetable(
+                createTime = createTime,
+                year = year,
+                semester = semester,
+                name = name,
+            )
+        }
+    }
 
     data class Param(
         val createTime: Long,


### PR DESCRIPTION
- Timetable 관련 UseCase에 TimetableRepository를 주입하고, 해당 Repository를 사용하도록 로직을 수정했습니다.
- Koin 모듈 정의에서 UseCase 생성 시 Repository를 주입하도록 변경했습니다.