### PR TITLE
feat: OpenLecture Data Layer 작업

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/openlecture/OpenLectureRaw.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/openlecture/OpenLectureRaw.kt
@@ -1,0 +1,11 @@
+package com.chukchukhaksa.mobile.data.openlecture
+
+data class OpenLectureRaw(
+  val number: Long = 0, // 번호
+  val major: String = "", // 개설학과
+  val grade: Int = 1, // 개설학년
+  val className: String = "", // 과목명
+  val classification: String = "", // 이수 구분
+  val professor: String = "",
+  val time: String = "",
+)

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/openlecture/datasource/LocalOpenLectureDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/openlecture/datasource/LocalOpenLectureDataSource.kt
@@ -1,0 +1,18 @@
+package com.chukchukhaksa.mobile.data.openlecture.datasource
+
+import com.chukchukhaksa.mobile.common.model.OpenLecture
+import kotlinx.coroutines.flow.Flow
+
+interface LocalOpenLectureDataSource {
+  fun getOpenLectureListVersion(): Flow<Long?>
+
+  suspend fun setOpenLectureListVersion(version: Long)
+
+  fun getOpenLectureList(
+    lectureOrProfessorName: String? = null,
+    major: String? = null,
+    grade: Int? = null
+  ): List<OpenLecture>
+
+  suspend fun updateAllLectures(lectures: List<OpenLecture>)
+}

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/openlecture/datasource/LocalOpenLectureDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/openlecture/datasource/LocalOpenLectureDataSource.kt
@@ -8,7 +8,7 @@ interface LocalOpenLectureDataSource {
 
   suspend fun setOpenLectureListVersion(version: Long)
 
-  fun getOpenLectureList(
+  suspend fun getOpenLectureList(
     lectureOrProfessorName: String? = null,
     major: String? = null,
     grade: Int? = null

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/openlecture/datasource/RemoteOpenLectureDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/openlecture/datasource/RemoteOpenLectureDataSource.kt
@@ -1,0 +1,8 @@
+package com.chukchukhaksa.mobile.data.openlecture.datasource
+
+import com.chukchukhaksa.mobile.data.openlecture.OpenLectureRaw
+
+interface RemoteOpenLectureDataSource {
+  suspend fun getOpenLectureListVersion(): Long
+  suspend fun getOpenLectureList(): List<OpenLectureRaw>
+}

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/openlecture/di/OpenLectureRepositoryModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/openlecture/di/OpenLectureRepositoryModule.kt
@@ -1,0 +1,9 @@
+package com.chukchukhaksa.mobile.data.openlecture.di
+
+import com.chukchukhaksa.mobile.domain.timetable.repository.OpenLectureRepository
+import com.chukchukhaksa.mobile.data.openlecture.repository.OpenLectureRepositoryImpl
+import org.koin.dsl.module
+
+val openLectureRepositoryModule = module {
+  single<OpenLectureRepository> { OpenLectureRepositoryImpl(get(), get()) }
+}

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/openlecture/repository/OpenLectureRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/openlecture/repository/OpenLectureRepositoryImpl.kt
@@ -1,0 +1,83 @@
+package com.chukchukhaksa.mobile.data.openlecture.repository
+
+import com.chukchukhaksa.mobile.common.model.OpenLecture
+import com.chukchukhaksa.mobile.domain.timetable.repository.OpenLectureRepository
+import com.chukchukhaksa.mobile.data.openlecture.datasource.LocalOpenLectureDataSource
+import com.chukchukhaksa.mobile.data.openlecture.datasource.RemoteOpenLectureDataSource
+import com.chukchukhaksa.mobile.data.timetable.TimetableUtil
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import kotlinx.datetime.LocalDateTime
+
+class OpenLectureRepositoryImpl(
+  private val remoteOpenLectureDataSource: RemoteOpenLectureDataSource,
+  private val localOpenLectureDataSource: LocalOpenLectureDataSource,
+) : OpenLectureRepository {
+  override fun getOpenLectureList(
+    lectureOrProfessorName: String?,
+    major: String?,
+    grade: Int?,
+  ): List<OpenLecture> {
+    return localOpenLectureDataSource.getOpenLectureList(
+      lectureOrProfessorName = lectureOrProfessorName,
+      major = major,
+      grade = grade,
+    )
+  }
+
+  override suspend fun checkNeedUpdate(): Boolean {
+    val localVersion = localOpenLectureDataSource.getOpenLectureListVersion().firstOrNull() ?: return true
+    val remoteVersion = remoteOpenLectureDataSource.getOpenLectureListVersion()
+    return remoteVersion > localVersion
+  }
+
+  override suspend fun updateAllLectures() = coroutineScope {
+    val remoteOpenLectures = async {
+      remoteOpenLectureDataSource.getOpenLectureList().map {
+        OpenLecture(
+          id = it.number,
+          name = it.className,
+          type = it.classification,
+          major = it.major,
+          grade = it.grade,
+          professorName = it.professor,
+          originalCellList = TimetableUtil.parseTimeTableString(it.time),
+        )
+      }
+    }
+
+    val remoteOpenLectureVersion = async {
+      remoteOpenLectureDataSource.getOpenLectureListVersion()
+    }
+
+    localOpenLectureDataSource.updateAllLectures(remoteOpenLectures.await())
+    localOpenLectureDataSource.setOpenLectureListVersion(remoteOpenLectureVersion.await())
+  }
+
+  override suspend fun getLastUpdatedDate(): String? {
+    return try {
+      val version = localOpenLectureDataSource.getOpenLectureListVersion().firstOrNull()?.toString()
+      if (version == null || version.length != 12) return null
+
+      val year = version.substring(0, 4).toInt()
+      val month = version.substring(4, 6).toInt()
+      val day = version.substring(6, 8).toInt()
+      val hour = version.substring(8, 10).toInt()
+      val minute = version.substring(10, 12).toInt()
+
+      val dateTime = LocalDateTime(year, month, day, hour, minute)
+
+      "${dateTime.year}년 ${dateTime.monthNumber}월 ${dateTime.dayOfMonth}일 " +
+              "${dateTime.hour}시 ${dateTime.minute}분"
+    } catch (e: Exception) {
+      null
+    }
+  }
+
+  override fun getOpenMajor(): List<String> {
+    return localOpenLectureDataSource.getOpenLectureList().map { list -> list.major }
+  }
+}

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/openlecture/repository/OpenLectureRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/openlecture/repository/OpenLectureRepositoryImpl.kt
@@ -16,7 +16,7 @@ class OpenLectureRepositoryImpl(
   private val remoteOpenLectureDataSource: RemoteOpenLectureDataSource,
   private val localOpenLectureDataSource: LocalOpenLectureDataSource,
 ) : OpenLectureRepository {
-  override fun getOpenLectureList(
+  override suspend fun getOpenLectureList(
     lectureOrProfessorName: String?,
     major: String?,
     grade: Int?,
@@ -77,7 +77,7 @@ class OpenLectureRepositoryImpl(
     }
   }
 
-  override fun getOpenMajor(): List<String> {
+  override suspend fun getOpenMajor(): List<String> {
     return localOpenLectureDataSource.getOpenLectureList().map { list -> list.major }
   }
 }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/timetable/TimetableUtil.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/data/timetable/TimetableUtil.kt
@@ -1,0 +1,59 @@
+package com.chukchukhaksa.mobile.data.timetable
+
+import com.chukchukhaksa.mobile.common.model.Cell
+import com.chukchukhaksa.mobile.common.model.TimetableDay
+
+
+object TimetableUtil {
+  fun parseTimeTableString(input: String): List<Cell> {
+    val cellRegex = """([^(]+)\(([^)]+)\)""".toRegex()
+    val dayPeriodRegex = """([월화수목금토])([\d,]+)""".toRegex()
+
+    val result = input.split("),").flatMap { cellInput ->
+      val sanitizedInput = if (!cellInput.endsWith(")")) "$cellInput)" else cellInput
+      cellRegex.find(sanitizedInput)?.let { cellMatch ->
+        val (location, schedule) = cellMatch.destructured
+        val trimmedLocation = location.trim()
+        dayPeriodRegex.findAll(schedule).flatMap { dayPeriodMatch ->
+          val (day, periods) = dayPeriodMatch.destructured
+          val periodList = periods.split(",").map { it.toInt() }
+
+          periodList.groupConsecutive().map { (start, end) ->
+            Cell(
+              location = trimmedLocation,
+              day = when (day) {
+                "월" -> TimetableDay.MON
+                "화" -> TimetableDay.TUE
+                "수" -> TimetableDay.WED
+                "목" -> TimetableDay.THU
+                "금" -> TimetableDay.FRI
+                "토" -> TimetableDay.SAT
+                else -> throw IllegalArgumentException("Invalid day: $day")
+              },
+              startPeriod = start,
+              endPeriod = end
+            )
+          }
+        }.toList()
+      } ?: emptyList()
+    }
+
+    return result
+  }
+
+  private fun List<Int>.groupConsecutive(): List<Pair<Int, Int>> {
+    if (isEmpty()) return emptyList()
+    val result = mutableListOf<Pair<Int, Int>>()
+    var start = this[0]
+    var prev = start
+    for (i in 1 until size) {
+      if (this[i] != prev + 1) {
+        result.add(start to prev)
+        start = this[i]
+      }
+      prev = this[i]
+    }
+    result.add(start to prev)
+    return result
+  }
+}

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/di/InitKoin.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/di/InitKoin.kt
@@ -1,9 +1,13 @@
 package com.chukchukhaksa.mobile.di
 
+import com.chukchukhaksa.mobile.data.openlecture.di.openLectureRepositoryModule
+import com.chukchukhaksa.mobile.data.openmajor.di.openMajorRepositoryModule
 import com.chukchukhaksa.mobile.data.timetable.di.timetableRepositoryModule
 import com.chukchukhaksa.mobile.local.database.common.di.openLectureDatabaseModule
 import com.chukchukhaksa.mobile.local.database.common.di.openMajorDatabaseModule
 import com.chukchukhaksa.mobile.local.database.common.di.timetableDatabaseModule
+import com.chukchukhaksa.mobile.local.datasource.openlecture.di.localOpenLectureDataSourceModule
+import com.chukchukhaksa.mobile.local.datasource.openmajor.di.localOpenMajorDataSourceModule
 import com.chukchukhaksa.mobile.local.datasource.timetable.di.localTimetableDataSourceModule
 import com.chukchukhaksa.mobile.local.datastore.di.dataStoreModule
 import org.koin.core.context.startKoin
@@ -21,7 +25,11 @@ fun initKoin(config: KoinAppDeclaration? = null) {
             openLectureDatabaseModule,
             localTimetableDataSourceModule,
             timetableRepositoryModule,
-            presentationModule
+            localOpenMajorDataSourceModule,
+            openMajorRepositoryModule,
+            localOpenLectureDataSourceModule,
+            openLectureRepositoryModule,
+            presentationModule,
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/timetable/repository/OpenLectureRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/timetable/repository/OpenLectureRepository.kt
@@ -8,7 +8,7 @@ interface OpenLectureRepository {
         lectureOrProfessorName: String? = null,
         major: String? = null,
         grade: Int? = null,
-    ): Flow<List<OpenLecture>>
+    ): List<OpenLecture>
 
     suspend fun checkNeedUpdate(): Boolean
 
@@ -16,5 +16,5 @@ interface OpenLectureRepository {
 
     suspend fun getLastUpdatedDate(): String?
 
-    suspend fun getOpenMajor(): List<String>
+    fun getOpenMajor(): List<String>
 }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/timetable/repository/OpenLectureRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/timetable/repository/OpenLectureRepository.kt
@@ -4,7 +4,7 @@ import com.chukchukhaksa.mobile.common.model.OpenLecture
 import kotlinx.coroutines.flow.Flow
 
 interface OpenLectureRepository {
-    fun getOpenLectureList(
+    suspend fun getOpenLectureList(
         lectureOrProfessorName: String? = null,
         major: String? = null,
         grade: Int? = null,
@@ -16,5 +16,5 @@ interface OpenLectureRepository {
 
     suspend fun getLastUpdatedDate(): String?
 
-    fun getOpenMajor(): List<String>
+    suspend fun getOpenMajor(): List<String>
 }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/local/database/openlecture/dao/OpenLectureDao.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/local/database/openlecture/dao/OpenLectureDao.kt
@@ -19,7 +19,7 @@ interface OpenLectureDao {
         AND (:grade IS NULL OR grade = :grade)
     """
     )
-    fun searchLectures(
+    suspend fun searchLectures(
         lectureOrProfessorName: String? = null,
         major: String? = null,
         grade: Int? = null

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/local/database/openlecture/dao/OpenLectureDao.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/local/database/openlecture/dao/OpenLectureDao.kt
@@ -19,7 +19,7 @@ interface OpenLectureDao {
         AND (:grade IS NULL OR grade = :grade)
     """
     )
-    suspend fun searchLectures(
+    fun searchLectures(
         lectureOrProfessorName: String? = null,
         major: String? = null,
         grade: Int? = null

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/local/datasource/openlecture/converter/OpenLectureEntity.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/local/datasource/openlecture/converter/OpenLectureEntity.kt
@@ -1,0 +1,40 @@
+package com.chukchukhaksa.mobile.local.datasource.openlecture.converter
+
+import com.chukchukhaksa.mobile.common.model.Cell
+import com.chukchukhaksa.mobile.common.model.OpenLecture
+import com.chukchukhaksa.mobile.local.database.openlecture.entity.CellEntity
+import com.chukchukhaksa.mobile.local.database.openlecture.entity.OpenLectureEntity
+
+fun OpenLectureEntity.toModel() = OpenLecture(
+  id = id,
+  name = name,
+  type = type,
+  major = major,
+  grade = grade,
+  professorName = professorName,
+  originalCellList = cellList.map { it.toModel() }
+)
+
+fun OpenLecture.toEntity() = OpenLectureEntity(
+  id = id,
+  name = name,
+  type = type,
+  major = major,
+  grade = grade,
+  professorName = professorName,
+  cellList = originalCellList.map { it.toEntity() }
+)
+
+fun Cell.toEntity() = CellEntity(
+  location = location,
+  day = day,
+  startPeriod = startPeriod,
+  endPeriod = endPeriod,
+)
+
+fun CellEntity.toModel() = Cell(
+  location = location,
+  day = day,
+  startPeriod = startPeriod,
+  endPeriod = endPeriod,
+)

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/local/datasource/openlecture/datasource/LocalOpenLectureDatasourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/local/datasource/openlecture/datasource/LocalOpenLectureDatasourceImpl.kt
@@ -36,7 +36,7 @@ class LocalOpenLectureDatasourceImpl(
     dataStore.edit { it[OPEN_LECTURE_LIST_VERSION] = version }
   }
 
-  override fun getOpenLectureList(
+  override suspend fun getOpenLectureList(
     lectureOrProfessorName: String?,
     major: String?,
     grade: Int?,

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/local/datasource/openlecture/datasource/LocalOpenLectureDatasourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/local/datasource/openlecture/datasource/LocalOpenLectureDatasourceImpl.kt
@@ -1,0 +1,58 @@
+package com.chukchukhaksa.mobile.local.datasource.openlecture.datasource
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import com.chukchukhaksa.mobile.common.model.OpenLecture
+import com.chukchukhaksa.mobile.data.openlecture.datasource.LocalOpenLectureDataSource
+import com.chukchukhaksa.mobile.local.database.openlecture.database.OpenLectureDatabase
+import com.chukchukhaksa.mobile.local.datasource.openlecture.converter.toEntity
+import com.chukchukhaksa.mobile.local.datasource.openlecture.converter.toModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+
+class LocalOpenLectureDatasourceImpl(
+  private val dataStore: DataStore<Preferences>,
+  private val openLectureDatabase: OpenLectureDatabase,
+) : LocalOpenLectureDataSource {
+  private val ioDispatcher = Dispatchers.IO
+
+  companion object {
+    private val OPEN_LECTURE_LIST_VERSION = longPreferencesKey("[KEY] is open lecture list version")
+  }
+
+  private val data: Flow<Preferences>
+    get() = dataStore.data
+
+  override fun getOpenLectureListVersion(): Flow<Long?> {
+    return data.map { it[OPEN_LECTURE_LIST_VERSION] }
+  }
+
+  override suspend fun setOpenLectureListVersion(version: Long) {
+    dataStore.edit { it[OPEN_LECTURE_LIST_VERSION] = version }
+  }
+
+  override fun getOpenLectureList(
+    lectureOrProfessorName: String?,
+    major: String?,
+    grade: Int?,
+  ): List<OpenLecture> {
+    return openLectureDatabase
+      .openLectureDao()
+      .searchLectures(
+        lectureOrProfessorName = lectureOrProfessorName,
+        major = major,
+        grade = grade,
+      ).map { list -> list.toModel() }
+  }
+
+  override suspend fun updateAllLectures(lectures: List<OpenLecture>) = withContext(ioDispatcher) {
+    openLectureDatabase
+      .openLectureDao()
+      .updateAllLectures(lectures.map { it.toEntity() })
+  }
+}

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/local/datasource/openlecture/di/LocalOpenLectureDataSourceModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/local/datasource/openlecture/di/LocalOpenLectureDataSourceModule.kt
@@ -1,0 +1,12 @@
+package com.chukchukhaksa.mobile.local.datasource.openlecture.di
+
+import com.chukchukhaksa.mobile.data.openlecture.datasource.LocalOpenLectureDataSource
+import com.chukchukhaksa.mobile.local.datasource.openlecture.datasource.LocalOpenLectureDatasourceImpl
+import org.koin.core.qualifier.named
+import org.koin.dsl.module
+
+val localOpenLectureDataSourceModule = module {
+  single<LocalOpenLectureDataSource>{
+    LocalOpenLectureDatasourceImpl(get(named("normalDataStore")), get())
+  }
+}


### PR DESCRIPTION
- `OpenMajor` 데이터 모델을 추가했습니다.
- 개설학과 정보 조회를 위한 DataSource 인터페이스 및 구현체를 추가했습니다.
- 개설학과 정보 Repository 인터페이스 및 구현체를 추가했습니다.
- Koin 모듈에 개설학과 관련 의존성을 추가했습니다.

suspend 함수에서 Flow 반환 하지 못해서 suwiki 코드 대비 리턴 타입 수정한 부분 있는데, 이 부분 확인 부탁 드립니다.
ex) getOpenLectureList() 

제 로컬에서는 빌드 확인 했습니다. ios 환경 빌드 여부 확인 부탁드립니다. 
-> 확인 후 머지 하겠습니다.