### PR TITLE
feat: Firebase 초기화 및 Napier 로깅 설정 개선

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/chukchukhaksa/mobile/ChukChukHaksaApplication.kt
+++ b/composeApp/src/androidMain/kotlin/com/chukchukhaksa/mobile/ChukChukHaksaApplication.kt
@@ -4,17 +4,11 @@ import android.app.Application
 import com.chukchukhaksa.mobile.di.initKoin
 import com.google.firebase.Firebase
 import com.google.firebase.initialize
-import io.github.aakira.napier.DebugAntilog
-import io.github.aakira.napier.Napier
 import org.koin.android.ext.koin.androidContext
 
 class ChukChukHaksaApplication : Application() {
     override fun onCreate() {
         super.onCreate()
-
-        if (BuildConfig.DEBUG) {
-            Napier.base(DebugAntilog())
-        }
 
         initKoin {
             androidContext(this@ChukChukHaksaApplication)

--- a/composeApp/src/androidMain/kotlin/com/chukchukhaksa/mobile/common/kmp/isDebug.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/chukchukhaksa/mobile/common/kmp/isDebug.android.kt
@@ -1,0 +1,7 @@
+package com.chukchukhaksa.mobile.common.kmp
+
+import com.chukchukhaksa.mobile.BuildConfig
+
+actual val isDebug: Boolean = BuildConfig.DEBUG
+
+

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/App.kt
@@ -6,9 +6,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.navigation.compose.NavHost
 import com.chukchukhaksa.mobile.common.designsystem.theme.SuwikiTheme
+import com.chukchukhaksa.mobile.common.kmp.isDebug
 import com.chukchukhaksa.mobile.presentation.openmajor.navigation.OpenMajorRoute
 import com.chukchukhaksa.mobile.presentation.openmajor.navigation.openMajorNavGraph
 import com.chukchukhaksa.mobile.presentation.timetable.navigation.timetableNavGraph
+import io.github.aakira.napier.DebugAntilog
+import io.github.aakira.napier.Napier
 import org.koin.compose.KoinContext
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -30,6 +33,12 @@ fun App(
 
             LaunchedEffect(key1 = Unit) {
 //            viewModel.checkUpdateMandatory(context.versionCode)
+            }
+
+            LaunchedEffect(Unit) {
+                if (isDebug) {
+                    Napier.base(DebugAntilog())
+                }
             }
 
             Scaffold(

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/kmp/isDebug.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/kmp/isDebug.kt
@@ -1,0 +1,3 @@
+package com.chukchukhaksa.mobile.common.kmp
+
+expect val isDebug: Boolean

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/timetable/usecase/UpdateOpenLectureIfNeedUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/domain/timetable/usecase/UpdateOpenLectureIfNeedUseCase.kt
@@ -7,7 +7,7 @@ class UpdateOpenLectureIfNeedUseCase(
     private val openLectureRepository: OpenLectureRepository,
 ) {
     suspend operator fun invoke(): Result<Unit> = runCatchingIgnoreCancelled {
-//        if (openLectureRepository.checkNeedUpdate().not()) return@runCatchingIgnoreCancelled
+        if (openLectureRepository.checkNeedUpdate().not()) return@runCatchingIgnoreCancelled
         openLectureRepository.updateAllLectures()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/openlecture/OpenLectureViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/presentation/timetable/openlecture/OpenLectureViewModel.kt
@@ -46,9 +46,6 @@ class OpenLectureViewModel(
         if (isFirstVisit) {
             mviStore.setState { copy(isLoading = true) }
             updateOpenLectureIfNeedUseCase()
-                .onFailure {
-                    Napier.d("${it.message}", tag = "OpenLectureViewModel")
-                }
             val lastUpdated = openLectureRepository.getLastUpdatedDate()
             mviStore.setState {
                 copy(

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/remote/timetable/RemoteOpenLectureDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/remote/timetable/RemoteOpenLectureDataSourceImpl.kt
@@ -17,7 +17,7 @@ class RemoteOpenLectureDataSourceImpl : RemoteOpenLectureDataSource {
             setLoggingEnabled(true)
         }
 
-    override suspend fun getOpenLectureListVersion(): Long = withContext(Dispatchers.IO) {
+    override suspend fun getOpenLectureListVersion(): Long =
         firebaseDatabase
             .reference(DATABASE_OPEN_LECTURE_VERSION)
             .valueEvents
@@ -25,18 +25,15 @@ class RemoteOpenLectureDataSourceImpl : RemoteOpenLectureDataSource {
             .value
             .toString()
             .toLongOrNull() ?: 0
-    }
 
-
-    override suspend fun getOpenLectureList(): List<OpenLectureRaw> = withContext(Dispatchers.IO) {
-        Napier.d(message = "getOpenLectureList", tag = "getOpenLectureList()")
-        val result = firebaseDatabase
+    override suspend fun getOpenLectureList(): List<OpenLectureRaw> =
+        firebaseDatabase
             .reference(DATABASE_OPEN_LECTURE)
             .valueEvents
             .first()
             .children
             .mapIndexed { index, dataSnapshot ->
-                val data = dataSnapshot.value as HashMap<*, *>
+                val data = dataSnapshot.value as Map<*, *>
                 OpenLectureRaw(
                     number = index.toLong() + 1,
                     major = data[FIELD_MAJOR].toString(),
@@ -47,10 +44,6 @@ class RemoteOpenLectureDataSourceImpl : RemoteOpenLectureDataSource {
                     time = data[FIELD_TIME]?.toString() ?: DEFAULT,
                 )
             }
-        Napier.d(message = "getOpenLectureList", tag = "getOpenLectureList result: $result")
-
-        result
-    }
 
 
     companion object {

--- a/composeApp/src/iosMain/kotlin/com/chukchukhaksa/mobile/common/kmp/isDebug.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/chukchukhaksa/mobile/common/kmp/isDebug.ios.kt
@@ -1,0 +1,7 @@
+package com.chukchukhaksa.mobile.common.kmp
+
+import kotlin.experimental.ExperimentalNativeApi
+import kotlin.native.Platform
+
+@OptIn(ExperimentalNativeApi::class)
+actual val isDebug: Boolean = Platform.isDebugBinary

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -4,7 +4,7 @@ import SwiftUI
 @main
 struct iOSApp: App {
     init() {
-      FirebaseApp.configure()
+        FirebaseApp.configure()
     }
 
     var body: some Scene {


### PR DESCRIPTION
- Android 및 iOS 플랫폼에서 Firebase 초기화 방식을 개선했습니다.
- Napier 로깅 설정을 `App.kt`로 이동하고, 디버그 빌드에서만 `DebugAntilog`를 사용하도록 수정했습니다.
- `isDebug` 플래그를 멀티플랫폼으로 구현하여 각 플랫폼에 맞는 디버그 확인 로직을 적용했습니다.
- `OpenLectureViewModel`에서 불필요한 오류 로깅을 제거했습니다.
- `RemoteOpenLectureDataSourceImpl`에서 불필요한 `withContext(Dispatchers.IO)` 및 로깅을 제거했습니다.
- `UpdateOpenLectureIfNeedUseCase`에서 불필요한 주석을 제거했습니다.