### PR TITLE
feat: 상태 바 색상 변경 기능 추가

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -71,6 +71,9 @@ kotlin {
             implementation(libs.kmp.firebase.crashlytics)
             implementation(libs.kmp.firebase.analytics)
             implementation(libs.napier)
+
+            implementation(libs.accompanist.systemuicontroller)
+
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/composeApp/src/androidMain/kotlin/com/chukchukhaksa/mobile/common/kmp/Platform.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/chukchukhaksa/mobile/common/kmp/Platform.android.kt
@@ -1,3 +1,17 @@
 package com.chukchukhaksa.mobile.common.kmp
 
+import androidx.compose.ui.graphics.Color
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
+
 actual fun getPlatform(): Platform = Platform.Android
+
+@Composable
+actual fun SetStatusBarColor(){
+    val sysUiController = rememberSystemUiController()
+
+    SideEffect {
+        sysUiController.setSystemBarsColor(color = Color(0xFFfbfbfb))
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/App.kt
@@ -21,6 +21,7 @@ import com.chukchukhaksa.mobile.common.designsystem.component.dialog.SuwikiDialo
 import com.chukchukhaksa.mobile.common.designsystem.component.toast.SuwikiToast
 import com.chukchukhaksa.mobile.common.designsystem.theme.SuwikiTheme
 import com.chukchukhaksa.mobile.common.designsystem.theme.White
+import com.chukchukhaksa.mobile.common.kmp.SetStatusBarColor
 import com.chukchukhaksa.mobile.common.ui.collectWithLifecycle
 import com.chukchukhaksa.mobile.presentation.openmajor.navigation.OpenMajorRoute
 import com.chukchukhaksa.mobile.presentation.openmajor.navigation.openMajorNavGraph
@@ -35,6 +36,7 @@ fun App(
     viewModel: MainViewModel = koinViewModel(),
     navigator: MainNavigator = rememberMainNavigator(),
 ) {
+    SetStatusBarColor()
     SuwikiTheme {
         KoinContext {
             val uiState = viewModel.mviStore.uiState.collectAsState().value

--- a/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/kmp/Platform.kt
+++ b/composeApp/src/commonMain/kotlin/com/chukchukhaksa/mobile/common/kmp/Platform.kt
@@ -1,8 +1,13 @@
 package com.chukchukhaksa.mobile.common.kmp
 
+import androidx.compose.runtime.Composable
+
 enum class Platform {
     Android,
     IOS
 }
 
 expect fun getPlatform(): Platform
+
+@Composable
+expect fun SetStatusBarColor()

--- a/composeApp/src/iosMain/kotlin/com/chukchukhaksa/mobile/common/kmp/Platform.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/chukchukhaksa/mobile/common/kmp/Platform.ios.kt
@@ -1,3 +1,50 @@
 package com.chukchukhaksa.mobile.common.kmp
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.zeroValue
+import platform.CoreGraphics.CGRect
+import platform.UIKit.UIApplication
+import platform.UIKit.UIColor
+import platform.UIKit.UIView
+import platform.UIKit.UIWindow
+import platform.UIKit.statusBarManager
+import androidx.compose.runtime.SideEffect
+
 actual fun getPlatform(): Platform = Platform.IOS
+
+@OptIn(ExperimentalForeignApi::class)
+@Composable
+private fun statusBarView() = remember {
+    val keyWindow: UIWindow? =
+        UIApplication.sharedApplication.windows.firstOrNull { (it as? UIWindow)?.isKeyWindow() == true } as? UIWindow
+    val tag = 3848245L
+
+    keyWindow?.viewWithTag(tag) ?: run {
+        val height =
+            keyWindow?.windowScene?.statusBarManager?.statusBarFrame ?: zeroValue<CGRect>()
+        val statusBarView = UIView(frame = height)
+        statusBarView.tag = tag
+        statusBarView.layer.zPosition = 999999.0
+        keyWindow?.addSubview(statusBarView)
+        statusBarView
+    }
+}
+
+
+@Composable
+actual fun SetStatusBarColor() {
+    val statusBar = statusBarView()
+    SideEffect {
+        statusBar.backgroundColor = Color(0xFFfbfbfb).toUIColor()
+    }
+}
+
+private fun Color.toUIColor(): UIColor = UIColor(
+    red = this.red.toDouble(),
+    green = this.green.toDouble(),
+    blue = this.blue.toDouble(),
+    alpha = this.alpha.toDouble()
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+accompanistSystemuicontroller = "0.30.1"
 agp = "8.7.3"
 android-compileSdk = "35"
 android-minSdk = "28"
@@ -78,6 +79,7 @@ desugar-jdk-libs = { group = "com.android.tools", name = "desugar_jdk_libs", ver
 
 napier = { group = "io.github.aakira", name = "napier", version.ref = "napier" }
 
+accompanist-systemuicontroller = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanistSystemuicontroller" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
- `SetStatusBarColor` 컴포저블 함수를 추가하여 iOS와 Android에서 상태 바 색상을 변경할 수 있도록 했습니다.
- `App.kt`에서 `SetStatusBarColor` 함수를 호출하여 앱 전체의 상태 바 색상을 통일합니다.

제 단말, 에뮬레이터에서는 다크모드 일때도 동일한 상태 바가 표출 되는 것을 확인했습니다. 
ios 및 추가 확인 부탁드립니다.